### PR TITLE
Update Ruby 2.5.1 && Bundler 1.16.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.2.2'
+ruby '2.5.1'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ DEPENDENCIES
   zoomus
 
 RUBY VERSION
-   ruby 2.2.2p95
+   ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.16.6


### PR DESCRIPTION
refs #20 
`bin/rails test` が通ることを確認済み。